### PR TITLE
Fix typographical error(s)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ You can get the app one of two ways:
 
 ## ARKit
 
-I recently introduced augmented reality into the app. I'm using [my own fork](https://github.com/markrickert/iPhone-AR-Toolkit) of [a1phanumeric](https://github.com/a1phanumeric)'s [iPhone AR Toolkit](https://github.com/a1phanumeric/iPhone-AR-Toolkit). The reason I'm using my own fork is becasue including it as a standard xcode project was crashing upon initialization. So I created a static library to use through XCode. I'll try and keep my fork up to date with the main project repo.
+I recently introduced augmented reality into the app. I'm using [my own fork](https://github.com/markrickert/iPhone-AR-Toolkit) of [a1phanumeric](https://github.com/a1phanumeric)'s [iPhone AR Toolkit](https://github.com/a1phanumeric/iPhone-AR-Toolkit). The reason I'm using my own fork is because including it as a standard xcode project was crashing upon initialization. So I created a static library to use through XCode. I'll try and keep my fork up to date with the main project repo.
 
 ## Screenshots
 


### PR DESCRIPTION
@OTGApps, I've corrected a typographical error in the documentation of the [WSCrime](https://github.com/OTGApps/WSCrime) project. Specifically, I've changed becasue to because. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
